### PR TITLE
adds metadata remapping

### DIFF
--- a/backends/common/readMetaMap.cpp
+++ b/backends/common/readMetaMap.cpp
@@ -1,0 +1,61 @@
+/*
+Copyright 2013-present Barefoot Networks, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+// #include <lib/cstring>
+#include <cassert>
+#include <fstream>
+#include <iostream>
+#include <map>
+#include <string>
+
+typedef std::map<std::string, std::string> metadataRemapT;
+
+metadataRemapT *readMap(const char *filename) {
+    std::ifstream input;
+    input.open(filename);
+
+    metadataRemapT *remap = new metadataRemapT;
+    while(input.good()) {
+        std::string a, sep, b;
+        int c = input.peek();
+        if (c == EOF) return remap;
+        if (c == '#' || c == '\n') {
+            // a comment line. read and discard
+            input.ignore(256, '\n');
+            continue;
+        }
+        input >> a >> sep >> b;
+        if (a.length() > 0) {
+            std::cout << "from " << a << " to " << b << std::endl;
+            remap->emplace(a,b);
+        }
+    }
+    input.close();
+    return remap;
+}
+
+#if DEBUG
+int main(int argc, char **argv) {
+    if(argc < 2) {
+        std::cerr << "Usage: " << argv[0] << " <map_file>" << std::endl;
+        exit(1);
+    }
+    metadataRemapT *r = readMap(argv[1]);
+    assert(r);
+    std::cout << "remapping " << r->size() << " metadata fields" << std::endl;
+    delete r;
+    return 0;
+}
+#endif

--- a/p4include/p4d2model_bmss_meta.map
+++ b/p4include/p4d2model_bmss_meta.map
@@ -1,0 +1,29 @@
+# This file maps p4d2 metadata to the bmv2 simple switch standard and intrinsic metadata
+
+# parser
+parser_input_t.ingress_port       -> standard_metadata.ingress_port
+parser_input_t.resubmit_flag      -> standard_metadata.resubmit_flag
+# ingress input
+ingress_input_t.ingress_port      -> standard_metadata.ingress_port
+ingress_input_t.resubmit_flag     -> standard_metadata.resubmit_flag
+ingress_input_t.ingress_timestamp -> intrinsic_metadata.ingress_global_timestamp
+# ingress output
+ingress_output_t.egress_port      -> standard_metadata.egress_port
+ingress_output_t.mcast_group      -> intrinsic_metadata.mcast_grp
+ingress_output_t.clone_id         -> standard_metadata.clone_spec
+ingress_output_t.resubmit_flag    -> standard_metadata.resubmit_flag
+ingress_output_t.drop_flag        -> standard_metadata.drop
+ingress_output_t.egress_queue     -> standard_metadata.egress_spec
+# egress input
+egress_input_t.egress_port        -> standard_metadata.egress_port
+egress_input_t.egress_rid         -> intrinsic_metadata.egress_rid
+egress_input_t.clone_id           -> standard_metadata.clone_spec
+egress_input_t.packet_length      -> standard_metadata.packet_length
+egress_input_t.egress_queue       -> standard_metadata.egress_spec
+egress_input_t.enq_timestamp      -> queueing_metadata.enq_timestamp
+egress_input_t.deq_timedelta      -> queueing_metadata.deq_timedelta
+egress_input_t.enq_qdepth         -> queueing_metadata.enq_qdepth
+egress_input_t.deq_qdepth         -> queueing_metadata.deq_qdepth
+# egress output
+egress_output_t.clone_id          -> standard_metadata.clone_spec
+egress_output_t.drop_flag         -> standard_metadata.drop


### PR DESCRIPTION
Defines the mapping for the metadata defined in p4d2model to the bmv2
simple switch intrinsic/standard metadata and provides a read function
for the file that returns the remapping (map of string to string).

We need to hook this up with p4c such that it knows which file to load
depending on the architecture and the target. And probably just simply
visit all the metadata declarations in the program and add a name
annotation to remap the name. I hope that fields can take qualified
names.