### PR TITLE
support for directCounterMap

### DIFF
--- a/backends/bmv2/backend.cpp
+++ b/backends/bmv2/backend.cpp
@@ -418,9 +418,9 @@ void Backend::convert(const IR::ToplevelBlock* tb) {
         new VisitFunctor([this](){ addLocals(); }),
         new VisitFunctor([this](){ padScalars(); }),
         new VisitFunctor([this](){ addErrors(errors); }),
-        new ConvertExterns(&refMap, &typeMap, conv, externs),
+        new ConvertExterns(this),
         new ConvertParser(&refMap, &typeMap, conv, parsers),
-        new ConvertControl(&refMap, &typeMap, conv, &structure, pipelines, counters),
+        new ConvertControl(this),
         new ConvertDeparser(&refMap, &typeMap, conv, deparsers),
         new VisitFunctor([this](){ createActions(actions); }),
     };

--- a/backends/bmv2/backend.h
+++ b/backends/bmv2/backend.h
@@ -35,7 +35,10 @@ limitations under the License.
 
 namespace BMV2 {
 
+
 class Backend : public PassManager {
+    using DirectCounterMap = std::map<cstring, const IR::P4Table*>;
+
     ExpressionConverter*             conv;
     P4::ConvertEnums::EnumMapping*   enumMap;
     P4::P4CoreLibrary&               corelib;
@@ -45,6 +48,7 @@ class Backend : public PassManager {
     Util::JsonObject                 toplevel;
     P4::V2Model&                     model;
     P4V1::V1Model&                   v1model;
+    DirectCounterMap                 directCounterMap;
     DirectMeterMap                   meterMap;
     ErrorCodesMap                    errorCodesMap;
 
@@ -104,10 +108,14 @@ class Backend : public PassManager {
     void convert(const IR::ToplevelBlock* block);
     void serialize(std::ostream& out) const
     { toplevel.serialize(out); }
-    ExpressionConverter* getExpressionConverter() { return conv; };
-    DirectMeterMap&      getMeterMap() { return meterMap; }
-    P4::ReferenceMap&    getRefMap()   { return refMap; }
-    P4::TypeMap&         getTypeMap()  { return typeMap; }
+    P4::P4CoreLibrary &   getCoreLibrary() const   { return corelib; }
+    ExpressionConverter * getExpressionConverter() { return conv; };
+    DirectCounterMap &    getDirectCounterMap()    { return directCounterMap; }
+    DirectMeterMap &      getMeterMap()  { return meterMap; }
+    P4::V2Model &         getModel()     { return model; }
+    P4::ReferenceMap &    getRefMap()    { return refMap; }
+    ProgramParts &        getStructure() { return structure; }
+    P4::TypeMap &         getTypeMap()   { return typeMap; }
 };
 
 }  // namespace BMV2

--- a/backends/bmv2/bmv2.cpp
+++ b/backends/bmv2/bmv2.cpp
@@ -74,10 +74,8 @@ int main(int argc, char *const argv[]) {
     if (::errorCount() > 0 || toplevel == nullptr)
         return 1;
 
-=======
-    BMV2::JsonConverter converter(options);
+    BMV2::Backend backend(&midEnd.enumMap);
     try {
-        BMV2::Backend backend(&midEnd.enumMap);
         backend.addDebugHook(hook);
         backend.process(toplevel);
         backend.convert(toplevel);
@@ -87,7 +85,6 @@ int main(int argc, char *const argv[]) {
     }
     if (::errorCount() > 0)
         return 1;
->>>>>>> 0bfc94ee... adds an unimplemented exception and exception catching in drivers (#555)
 
     if (!options.outputFile.isNullOrEmpty()) {
         std::ostream* out = openFile(options.outputFile, false);

--- a/backends/bmv2/control.h
+++ b/backends/bmv2/control.h
@@ -127,14 +127,9 @@ class SharedActionSelectorCheck : public Inspector {
 };
 
 class Control : public Inspector {
-    P4::ReferenceMap*    refMap;
-    P4::TypeMap*         typeMap;
-    ExpressionConverter* conv;
-    ProgramParts*        structure;
-    Util::JsonArray*     counters;
-    Util::JsonArray*     pipelines;
-    P4::P4CoreLibrary&   corelib;
-    P4::V2Model&         v2model;
+    Backend*    backend;
+
+    // P4::V2Model&         v2model;
 
  protected:
     // helper function that create a JSON object for extern block
@@ -156,25 +151,13 @@ class Control : public Inspector {
     bool preorder(const IR::ControlBlock* b) override;
     bool preorder(const IR::Declaration_Instance* d) override;
 
-    explicit Control(P4::ReferenceMap* refMap, P4::TypeMap* typeMap,
-                                      ExpressionConverter* conv,
-                                      ProgramParts* structure, Util::JsonArray* pipelines,
-                                      Util::JsonArray* counters) :
-        refMap(refMap), typeMap(typeMap), conv(conv),
-        structure(structure), counters(counters), pipelines(pipelines),
-        corelib(P4::P4CoreLibrary::instance),
-        v2model(P4::V2Model::instance)
-        { CHECK_NULL(conv); }
-
+    explicit Control(Backend *backend) : backend(backend) {}
 };
 
 class ConvertControl final : public PassManager {
  public:
-    ConvertControl(P4::ReferenceMap* refMap, P4::TypeMap* typeMap,
-                   ExpressionConverter* conv,
-                   ProgramParts* structure, Util::JsonArray* pipelines,
-                   Util::JsonArray* counters) {
-        passes.push_back(new Control(refMap, typeMap, conv, structure, pipelines, counters));
+    ConvertControl(Backend *backend) {
+        passes.push_back(new Control(backend));
         setName("ConvertControl");
     }
 };

--- a/backends/bmv2/extern.cpp
+++ b/backends/bmv2/extern.cpp
@@ -76,7 +76,7 @@ bool Extern::preorder(const IR::Declaration_Instance* decl) {
             result->emplace("type", decl->type->to<IR::Type_Specialized>()->baseType->toString());
             auto attributes = mkArrayField(result, "attribute_values");
             addExternAttributes(decl, externBlock, attributes);
-            externs->append(result);
+            backend->externs->append(result);
         }
     }
     return false;

--- a/backends/bmv2/extern.h
+++ b/backends/bmv2/extern.h
@@ -26,10 +26,8 @@ limitations under the License.
 namespace BMV2 {
 
 class Extern : public Inspector {
-    P4::ReferenceMap*    refMap;
-    P4::TypeMap*         typeMap;
-    ExpressionConverter* conv;
-    Util::JsonArray*     externs;
+    Backend *backend;
+
  protected:
     void addExternAttributes(const IR::Declaration_Instance* di, const IR::ExternBlock* block,
                              Util::JsonArray* attributes);
@@ -38,16 +36,13 @@ class Extern : public Inspector {
     bool preorder(const IR::PackageBlock* b) override;
     bool preorder(const IR::Declaration_Instance* decl) override;
 
-    explicit Extern(P4::ReferenceMap* refMap, P4::TypeMap* typeMap,
-                                     ExpressionConverter* conv, Util::JsonArray* externs) :
-        refMap(refMap), typeMap(typeMap), conv(conv), externs(externs) {}
+    explicit Extern(Backend *b) : backend(b) {}
 };
 
 class ConvertExterns final : public PassManager {
  public:
-    ConvertExterns(P4::ReferenceMap* refMap, P4::TypeMap* typeMap,
-                   ExpressionConverter* conv, Util::JsonArray* externs) {
-       passes.push_back(new Extern(refMap, typeMap, conv, externs));
+    ConvertExterns(Backend *b) {
+       passes.push_back(new Extern(b));
        setName("ConvertExterns");
     }
 };

--- a/backends/ebpf/p4c-ebpf.cpp
+++ b/backends/ebpf/p4c-ebpf.cpp
@@ -70,7 +70,12 @@ int main(int argc, char *const argv[]) {
     if (::errorCount() > 0)
         exit(1);
 
-    compile(options);
+    try {
+        compile(options);
+    } catch (const Util::P4CExceptionBase &bug) {
+        std::cerr << bug.what() << std::endl;
+        return 1;
+    }
 
     if (Log::verbose())
         std::cerr << "Done." << std::endl;

--- a/lib/exceptions.h
+++ b/lib/exceptions.h
@@ -24,9 +24,14 @@ limitations under the License.
 
 namespace Util {
 
-// Base class for all exceptions.
-// The constructor uses boost::format for the format string, i.e.,
-// %1%, %2%, etc (starting at 1, not at 0)
+// colors to pretty print messages
+constexpr char ANSI_RED[]  = "\e[31m";
+constexpr char ANSI_BLUE[] = "\e[34m";
+constexpr char ANSI_CLR[]  = "\e[0m";
+
+/// Base class for all exceptions.
+/// The constructor uses boost::format for the format string, i.e.,
+/// %1%, %2%, etc (starting at 1, not at 0)
 class P4CExceptionBase : public std::exception {
  protected:
     cstring message;
@@ -35,29 +40,45 @@ class P4CExceptionBase : public std::exception {
     template <typename... T>
     P4CExceptionBase(const char* format, T... args) {
         boost::format fmt(format);
-        this->message = ::bug_helper(fmt, "", "", "", std::forward<T>(args)...);
+        message = ::bug_helper(fmt, "", "", "", std::forward<T>(args)...);
     }
 
     const char* what() const noexcept
-    { return this->message.c_str(); }
+    { return message.c_str(); }
 };
 
-// This class indicates a bug in the compiler
+/// This class indicates a bug in the compiler
 class CompilerBug final : public P4CExceptionBase {
  public:
     template <typename... T>
     CompilerBug(const char* format, T... args)
             : P4CExceptionBase(format, args...)
-    { message = "COMPILER BUG:\n" + message; }
+    { message = cstring(ANSI_RED) + "Compiler Bug" + ANSI_CLR + ":\n" + message; }
     template <typename... T>
     CompilerBug(const char* file, int line, const char* format, T... args)
             : P4CExceptionBase(format, args...)
-    { message = cstring("COMPILER BUG: ") + file + ":" + Util::toString(line) + "\n" + message; }
+    { message = cstring("In file: ") + file + ":" + Util::toString(line) + "\n" +
+                + ANSI_RED + "Compiler Bug" + ANSI_CLR + ": " + message; }
 };
 
-// This class indicates a compilation error that we do not want to recover from.
-// This may be due to a malformed input program.
-// TODO: this class is very seldom used, perhaps we can remove it.
+/// This class indicates an unimplemented feature in the compiler
+class CompilerUnimplemented final : public P4CExceptionBase {
+ public:
+    template <typename... T>
+    CompilerUnimplemented(const char* format, T... args)
+            : P4CExceptionBase(format, args...)
+    { message = cstring(ANSI_BLUE) +"Unimplemented compiler support"+ ANSI_CLR + ":\n" + message; }
+    template <typename... T>
+    CompilerUnimplemented(const char* file, int line, const char* format, T... args)
+            : P4CExceptionBase(format, args...)
+    { message = cstring("In file: ") + file + ":" + Util::toString(line) + "\n" +
+                ANSI_BLUE + "Unimplemented compiler support" + ANSI_CLR + ": " + message; }
+};
+
+
+/// This class indicates a compilation error that we do not want to recover from.
+/// This may be due to a malformed input program.
+/// TODO: this class is very seldom used, perhaps we can remove it.
 class CompilationError : public P4CExceptionBase {
  public:
     template <typename... T>
@@ -67,6 +88,9 @@ class CompilationError : public P4CExceptionBase {
 
 #define BUG(...) do { throw Util::CompilerBug(__FILE__, __LINE__, __VA_ARGS__); } while (0)
 #define BUG_CHECK(e, ...) do { if (!(e)) BUG(__VA_ARGS__); } while (0)
+#define P4C_UNIMPLEMENTED(...) do { \
+        throw Util::CompilerUnimplemented(__FILE__, __LINE__, __VA_ARGS__); \
+    } while (0)
 
 }  // namespace Util
 #endif /* P4C_LIB_EXCEPTIONS_H_ */

--- a/test/unittests/exception_test.cpp
+++ b/test/unittests/exception_test.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright 2013-present Barefoot Networks, Inc. 
+Copyright 2013-present Barefoot Networks, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -28,7 +28,8 @@ class TestException : public TestBase {
         }
         catch (std::exception &ex) {
             cstring err(ex.what());
-            ASSERT_EQ(err, "COMPILER BUG:\ntest\n");
+            cstring expected = cstring(ANSI_RED) + "Compiler Bug" + ANSI_CLR +":\ntest\n";
+            ASSERT_EQ(err, expected);
         }
 
         try {


### PR DESCRIPTION
There is one other place where i saw this used. jsonconverter was looking it up in the map:
```
                } else if (eb->type->name == v1model.directCounter.name) {
                    auto it = directCountersMap.find(name);
                    if (it == directCountersMap.end()) {
                        ::warning("%1%: Direct counter not used; ignoring", c);
                    } else {
```
That went out with the different handling of externs i suppose. In any case, it looks like the backend was not generating code for the extern if it was not used. How are we handling this case?