### PR TITLE
expands the v1model standard metadata to cover all metadata exposed b…

### DIFF
--- a/backends/bmv2/backend.h
+++ b/backends/bmv2/backend.h
@@ -105,7 +105,6 @@ class Backend : public PassManager {
     void convertActionBody(const IR::Vector<IR::StatOrDecl>* body, Util::JsonArray* result);
     void createActions(Util::JsonArray* actions);
     void createMetadata();
-    void createFieldAliases(const char *remapFile);
     void genExternMethod(Util::JsonArray* result, P4::ExternMethod *em);
     void padScalars();
 

--- a/p4include/v1model.p4
+++ b/p4include/v1model.p4
@@ -38,6 +38,18 @@ struct standard_metadata_t {
     bit<1>  drop;
     bit<16> recirculate_port;
     bit<32> packet_length;
+    // flattening fields that exist in bmv2-ss
+    // queueing metadata
+    @name("queueing_metadata.enq_timestamp") bit<32> enq_timestamp;
+    @name("queueing_metadata.enq_qdepth")    bit<19> enq_qdepth;
+    @name("queueing_metadata.deq_timedelta") bit<32> deq_timedelta;
+    @name("queueing_metadata.deq_qdepth")    bit<19> deq_qdepth;
+    // intrinsic metadata
+    @name("intrinsic_metadata.ingress_global_timestamp") bit<48> ingress_global_timestamp;
+    @name("intrinsic_metadata.lf_field_list") bit<32> lf_field_list;
+    @name("intrinsic_metadata.mcast_grp")     bit<16> mgast_grp;
+    @name("intrinsic_metadata.resubmit_flag") bit<1>  resubmit_flag;
+    @name("intrinsic_metadata.egress_rid")    bit<16> egress_rid;
 }
 
 extern Checksum16 {


### PR DESCRIPTION
…y simple switch

Allows access to bmv2 simple switch intrinsic and queueing metadata
for programs that use the v1model. While these metadata would be
available by defining separate metadata with the correct names, it is
desirable that the functionality is exposed in the architecture
definition. This patch will work with any metadata that has fields
renamed.

@hanw, I think I found a solution that doesn't require magically knowing the architecture ... or the target. It only ties the architecture to a target through the names of the metadata. Let me know what you think. 

I did protect the code with an #ifndef PSA, but that may not be necessary. As long as fields declared in metadata headers do not have a name annotation, there is nothing that gets generated.